### PR TITLE
Fix timeval redefinition

### DIFF
--- a/component/common/network/lwip/lwip_v1.4.1/port/realtek/arch/cc.h
+++ b/component/common/network/lwip/lwip_v1.4.1/port/realtek/arch/cc.h
@@ -33,6 +33,7 @@
 #define __CC_H__
 
 #include "cpu.h"
+#include <sys/time.h>
 
 typedef unsigned   char    u8_t;
 typedef signed     char    s8_t;

--- a/component/common/network/lwip/lwip_v1.4.1/src/include/lwip/sockets.h
+++ b/component/common/network/lwip/lwip_v1.4.1/src/include/lwip/sockets.h
@@ -306,7 +306,7 @@ typedef struct ip_mreq {
 /** LWIP_TIMEVAL_PRIVATE: if you want to use the struct timeval provided
  * by your system, set this to 0 and include <sys/time.h> in cc.h */ 
 #ifndef LWIP_TIMEVAL_PRIVATE
-#define LWIP_TIMEVAL_PRIVATE 1
+#define LWIP_TIMEVAL_PRIVATE 0
 #endif
 
 #if LWIP_TIMEVAL_PRIVATE


### PR DESCRIPTION
Hello @polyfractal and thanks very much for your work!

I was getting redefinition errors when attempting to build on Arch, with packages:

 - arm-none-eabi-gcc
 - arm-none-eabi-gdb
 - arm-none-eabi-newlib
 - arm-none-eabi-binutils

Specifically, `struct timeval` was redefined. It sounded identical to [this reported issue](https://developer.mbed.org/users/RyoheiHagimoto/notebook/compiler-error-of-ethernetinterface/). I tried following the instructions in `sockets.h` and that seemed to work nicely, so I submit the changes for your approval.

Could it cause problems on Ubuntu, as you seem not to have encountered this issue? Reject away if so!